### PR TITLE
feat: introduce CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Check out branch
         uses: actions/checkout@v3
-      - name: Install mdbook
+      - name: Install and run mdbook
         run: |
           mkdir bin
           curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.4.19/mdbook-v0.4.19-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=bin

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,18 @@
+# Workflow based on https://rust-lang.github.io/mdBook/continuous-integration.html
+
+name: Build
+
+on: pull_request
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out branch
+        uses: actions/checkout@v3
+      - name: Install mdbook
+        run: |
+          mkdir bin
+          curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.4.19/mdbook-v0.4.19-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=bin
+          bin/mdbook build

--- a/book.toml
+++ b/book.toml
@@ -1,4 +1,4 @@
-[bok]
+[book]
 authors = ["Magnus Madsen"]
 language = "en"
 multilingual = false

--- a/book.toml
+++ b/book.toml
@@ -1,4 +1,4 @@
-[book]
+[bok]
 authors = ["Magnus Madsen"]
 language = "en"
 multilingual = false


### PR DESCRIPTION
Fixes #15 

Just installs and runs `mdbook build` for now. The [Rust workflow](https://github.com/rust-lang/book/blob/main/.github/workflows/main.yml) is a bit more intensive and includes checking of spelling and tests the code. Presumably we could do something like this in the future.