### PR TITLE
add comment of example's tuple degree

### DIFF
--- a/src/tuples.md
+++ b/src/tuples.md
@@ -16,7 +16,7 @@ We can destructure a tuple using pattern matching.
 For example:
 
 ```flix
-let t = ("Lucky", "Luke", 42, true);
+let t = ("Lucky", "Luke", 42, true); // 4-tuple
 let (fstName, lstName, age, male) = t;
 lstName
 ```


### PR DESCRIPTION
Primed from the previous page's primitives examples that were nested ex. `Cons(1, Cons(2, Cons(3, Nil)))`, and the example on top that used a 2-tuple, I at first thought that the 4-tuple example was some form of syntactic sugar for a 2-tuple in a form either like `((a,b), (c,d))` or `(a, (b, (c, d)))`.