### PR TITLE
style: simplify summary

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -1,5 +1,7 @@
 # Summary
 
+# Core Language
+
 - [Introduction to Flix](./introduction.md)
 - [Data Types](./data-types.md)
   - [Primitives](./primitive-types.md)
@@ -30,14 +32,10 @@
   - [String Interpolation](./string-interpolation.md)
   - [Anonymous and Named Holes](./holes.md)
   - [Type Ascriptions](./type-ascriptions.md)
-- [Tools](./tools.md)
-  - [Visual Studio Code](./vscode.md)
-  - [Package Manager](./build-and-packages.md)
-  - [Test Framework](./test-framework.md)
 
 ---
 
-- [Advanced Features](./advanced-features.md)
+# Advanced Features
   - [Upcasts](./upcast.md)
   - [Type and Effect Casts](./casts.md)
   - [Bugs and Unreachable Code](./bug-and-unreachable.md)
@@ -45,6 +43,13 @@
 
 ---
 
-- [Appendix](./appendix.md)
+# Tools
+  - [Visual Studio Code](./vscode.md)
+  - [Package Manager](./build-and-packages.md)
+  - [Test Framework](./test-framework.md)
+
+---
+
+# Appendix
   - [Legal Identifiers](./identifiers.md)
   - [Operator Precedence](./precedence.md)

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -14,7 +14,7 @@
   - [References](./references.md)
   - [Arrays](./arrays.md)
 - [Control Structures](./control-structures.md)
-  - [If-Then-Else](./if-then-else.md)
+  - [If-Then-Else]()
   - [Pattern Matching](./pattern-matching.md)
   - [For-Each and For-Yield](./foreach-foryield.md)
 - [Concurrency](./concurrency.md)

--- a/src/advanced-features.md
+++ b/src/advanced-features.md
@@ -1,8 +1,0 @@
-# Advanced Features
-
-In this chapter, we discuss some advanced features of Flix, including:
-
-- [Safe Upcasts](./upcast.md)
-- [Unsafe Type and Effect Casts](./casts.md)
-- [Bugs and Reachable Code](./bug-and-unreachable.md)
-- [Purity Reflection](./purity-reflection.md)

--- a/src/appendix.md
+++ b/src/appendix.md
@@ -1,6 +1,0 @@
-# Append
-
-The appendix covers technical details such as:
-
-- [Legal Identifiers](./identifiers.md)
-- [Operator Precedence](./precedence.md)

--- a/src/if-then-else.md
+++ b/src/if-then-else.md
@@ -1,4 +1,0 @@
-# If-then-else
-
-> Under construction.
-

--- a/src/tools.md
+++ b/src/tools.md
@@ -1,7 +1,0 @@
-# Tools
-
-This chapter covers the tooling which Flix ships with, including:
-
-- A fully-featured [Visual Studio Code extension](./vscode.md).
-- A [package manager](./build-and-packages.md).
-- A built-in [test framework](./test-framework.md).


### PR DESCRIPTION
I've tried to clean up the summary / table of contents by separating each section more clearly. Thoughts?