### PR TITLE
refactor: update record member type ascription syntax

### DIFF
--- a/src/interoperability.md
+++ b/src/interoperability.md
@@ -100,7 +100,7 @@ can cast it from impure to pure, as the following
 example shows:
 
 ```flix
-def startsWith(prefix: {prefix :: String}, s: String): Bool =
+def startsWith(prefix: {prefix = String}, s: String): Bool =
     import java.lang.String.startsWith(String): Bool \ {};
     startsWith(s, prefix.prefix)
 ```

--- a/src/introduction.md
+++ b/src/introduction.md
@@ -42,7 +42,7 @@ Here is a Flix program using polymorphic records:
 /// Returns the area of the polymorphic record `r`.
 /// Note that the use of the type variable `a` permits the record `r`
 /// to have labels other than `x` and `y`.
-def polyArea[a : RecordRow](r: {x:: Int32, y:: Int32 | a}): Int32 = r.x * r.y
+def polyArea[a : RecordRow](r: {x = Int32, y = Int32 | a}): Int32 = r.x * r.y
 
 /// Computes the area of various rectangle records.
 /// Note that some records have additional fields.

--- a/src/records.md
+++ b/src/records.md
@@ -13,7 +13,7 @@ A record literal is written with curly braces:
 ```
 
 which has the record type
-`{ x :: Int32, y :: Int32 }`.
+`{ x = Int32, y = Int32 }`.
 
 The order of fields in a record does not matter,
 hence the above record is equivalent to the
@@ -24,9 +24,9 @@ record:
 ```
 
 which has the record type
-`{ y :: Int32, x :: Int32 }`.
+`{ y = Int32, x = Int32 }`.
 This type is equivalent to the record type
-`{ x :: Int32, y :: Int32 }`.
+`{ x = Int32, y = Int32 }`.
 That is, the order of fields within a record type do
 not matter.
 
@@ -97,7 +97,7 @@ A function may specify that it requires a record
 with two fields:
 
 ```flix
-def f(r: {x :: Int32, y :: Int32}): Int32 = r.x + r.y
+def f(r: {x = Int32, y = Int32}): Int32 = r.x + r.y
 ```
 
 We can call this function with the records
@@ -112,7 +112,7 @@ We can lift this restriction by using row
 polymorphism:
 
 ```flix
-def g(r: {x :: Int32, y :: Int32 | s}): Int32 = r.x + r.y
+def g(r: {x = Int32, y = Int32 | s}): Int32 = r.x + r.y
 ```
 
 We can call this function with *any* record as long
@@ -138,7 +138,7 @@ For example, we can write a function translate to
 translate from one language to another as follows:
 
 ```flix
-def translate(from: {from :: Language}, to: {to :: Language}, text: String): String = ???
+def translate(from: {from = Language}, to: {to = Language}, text: String): String = ???
 ```
 
 We can call this function as follows:

--- a/src/references.md
+++ b/src/references.md
@@ -150,7 +150,7 @@ r.fstName := "Unlucky"
 ```
 
 The type of the record is
-`{ fstName :: Ref[String], lstName :: Ref[String] }`.
+`{ fstName = Ref[String], lstName = Ref[String] }`.
 Again, the assignment does not change the record
 itself, but rather changes the value of the reference
 cell corresponding to the `fstName` field.


### PR DESCRIPTION
Updates the syntax for record member type ascription. From `::` to `=` as per https://github.com/flix/flix/pull/4526