### PR TITLE
chore: Changes to type parameter order where Result is quoted in code

### DIFF
--- a/src/data-types.md
+++ b/src/data-types.md
@@ -4,7 +4,7 @@ Flix comes with a collection of built-in data types,
 such as booleans, floats and integers, and
 compound types, such as tuples and records.
 Moreover, the standard library defines types such as
-`Option[a]`, `Result[t, e]`, `List[a]`, `Set[a]`,
+`Option[a]`, `Result[e, t]`, `List[a]`, `Set[a]`,
 and `Map[k, v]`.
 
 In addition to these types, Flix allows programmers

--- a/src/enums.md
+++ b/src/enums.md
@@ -136,7 +136,7 @@ For example, the standard library implement of the
 `Result` has two type parameters:
 
 ```flix
-enum Result[t, e] {
+enum Result[e, t] {
     case Ok(t),
     case Err(e)
 }

--- a/src/redundancy.md
+++ b/src/redundancy.md
@@ -98,10 +98,10 @@ with the message:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
         discarded value.
 
-The expression has type 'Result[Int64, String]'
+The expression has type 'Result[String, Int64]'
 ```
 
-Even though `File.creationTime` has a side-effects, we should probably be using the result `Result[Int64, String]`.
+Even though `File.creationTime` has a side-effects, we should probably be using the result `Result[String, Int64]`.
 At least to ensure that the operation was successful. 
 
 If the result of an impure expression is truly not needed, then the `discard` expression can be used:

--- a/src/type-aliases.md
+++ b/src/type-aliases.md
@@ -7,9 +7,9 @@ For example:
 ```flix
 ///
 /// A type alias for a map from keys of type `k`
-/// to values of type `Result[v, String]`
+/// to values of type `Result[String, v]`
 ///
-type alias M[k, v] = Map[k, Result[v, String]]
+type alias M[k, v] = Map[k, Result[String, v]]
 
 def foo(): M[Bool, Int32] = Map#{true => Ok(123)}
 ```


### PR DESCRIPTION
Type parameter order changes to the docs where `Result` appears in quoted code. This matches changes to the stdlib where Result and Validation have had their type parameter orders changed so they can have instances for `Functor`, etc.

The `Validation` type does not appear in quoted code.