### PR TITLE
chore: fix typos

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -5,3 +5,4 @@ By adding your name to this document, you agree to release all your contribution
 - [Magnus Madsen](https://github.com/magnus-madsen)
 - [Jakob Schneider](https://github.com/jaschdoc)
 - [Asger Alstrup Palm](https://github.com/alstrup)
+- [Herluf Baggesen](https://github.com/herluf-ba)

--- a/src/concurrency.md
+++ b/src/concurrency.md
@@ -14,7 +14,7 @@ def main(): Unit \ IO = region rc {
 }
 ```
 
-Spawned processes are always associated with a region; the region will
+Spawned processes are always associated with a region; the region 
 will not exit until all the processes associated with it have completed:
 
 ```flix

--- a/src/immutable-data.md
+++ b/src/immutable-data.md
@@ -20,7 +20,6 @@ Other immutable data types include:
 
 - `Option[t]`       : A type that is either `None` or `Some(t)`.
 - `Result[e, t]`    : A type that is either `Ok(t)` or `Err(e)`.
-- `Chain[t]`        : An immutable sequence of elements of type `t` that supports fast append.
 - `Nel[t]`          : An immutable non-empty singly-linked list of elements of type `t`.
 - `Nec[t]`          : An immutable non-empty sequence of elements of type `t` that supports fast append.
 - `MultiMap[k, v]`  : An immutable map of keys of type `k` to _sets_ of values of type `v`.

--- a/src/next-steps.md
+++ b/src/next-steps.md
@@ -3,8 +3,8 @@
 We are now ready write our first real program! 
 
 We will write a simple variant of the venerable wordcount (`wc`) program from
-UNIX. We shall not be concerned with efficiency, but we will carefully all error
-cases. 
+UNIX. We shall not be concerned with efficiency, but we will carefully check all 
+error cases. 
 
 Create a new folder (e.g. `wc`) and put the following code into `Main.flix`:
 
@@ -35,7 +35,7 @@ The program works as follows:
    We use pattern matching on `args` to extract the file name and report an
    error if the list is empty.
 2. We use `File.readLines` to read all lines of the file. This operation may
-   fail (e.g. if the file does not exist) and hence it returns a `Result`. We use pattern matching on the result an print an error message if we could not read the file.
+   fail (e.g. if the file does not exist) and hence it returns a `Result`. We use pattern matching on the result and print an error message if we could not read the file.
 3. Otherwise we have a `List[String]` from which we can easily compute the
    number of lines and using the helper function `numberOfWords`, we can also
    easily compute the total number of words. Finally, we print these two numbers.


### PR DESCRIPTION
A humble contribution, but a contribution none the less!

Additionally I was confused about the following things as I read through the book:
- The `!>` operator is used without introduction. I think a natural place to mention it would be under "Functions" > "Pipelines".
- I needed to run nightly to run many of the code examples. Maybe, while Flix hasn't reached a stable version yet it would be good to mention nightly in one of the first sections. Something like this would have helped me:
> Flix is actively being developed and haven't reached a stable version yet. Meanwhile we want to keep this book as in line with cutting edge Flix, so it is recommended that you use the [nightly build](https://flix.dev/nightly/) to make sure that you are able to run all examples.
       