### PR TITLE
fix: typo in Summary preventing Trait section to be shown

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -34,7 +34,7 @@
   - [Declaring Modules](./declaring-modules.md)
   - [Using Modules](./using-modules.md)
   - [Companion Modules](./companion-modules.md)
-- [Traits](./taits.md)
+- [Traits](./traits.md)
   - [Essential Traits](./essential-traits.md)
   - [Automatic Derivation](./automatic-derivation.md)
   - [Higher-Kinded Types](./higher-kinded-types.md)


### PR DESCRIPTION
As per title the [trait section](https://doc.flix.dev/taits.html) is currently empty since #110, see also image:

![image](https://github.com/flix/book/assets/11669196/810d5acf-911e-41f4-9e68-75c11cfd245f)

I considered also adding an automated check _"all files in summary actually exist"_ in the Github Action CI, but I'm not that skilled with bash scripting, sorry.
