### PR TITLE
feat: add sub section on record pattern matching

### DIFF
--- a/src/pattern-matching.md
+++ b/src/pattern-matching.md
@@ -25,7 +25,9 @@ def area(s: Shape): Int32 = match s {
 }
 ```
 
-This also works for record types; however, the syntax is slightly different.
+### Matching on Records
+
+The above also works for record types; however, the syntax is slightly different.
 Let us rewrite the `Shape` type from before, this time using records.
 
 ```flix


### PR DESCRIPTION
The section on records just extended the section on enums. This clearly separates the two.