### PR TITLE
docs: update `RecordSelect` syntax to `#`

### DIFF
--- a/src/common-problems.md
+++ b/src/common-problems.md
@@ -9,7 +9,7 @@
 Given the program:
 
 ```flix
-def main(): Unit \ IO = 
+def main(): Unit \ IO =
     let l = Nil;
     println(l)
 ```
@@ -28,12 +28,12 @@ The Flix compiler reports:
 
 The issue is that the empty list has the polymorphic type: `List[a]` for any
 `a`. This means that Flix cannot select the appropriate `ToString` trait
-instance. 
+instance.
 
 The solution is to specify the type of the empty list. For example, we can write:
 
 ```flix
-def main(): Unit \ IO = 
+def main(): Unit \ IO =
     let l: List[Int32] = Nil;
     println(l)
 ```
@@ -61,7 +61,7 @@ The Flix compiler reports:
              complex instance type
 ```
 
-This is because, at least for the moment, it is not possible type define 
+This is because, at least for the moment, it is not possible type define
 trait instances on records (or Datalog schema rows). This may change in the
 future. Until then, it is necessary to wrap the record in an algebraic data
 type. For example:
@@ -74,10 +74,10 @@ and then we can implement `Eq` for the `Person` type:
 
 ```flix
 instance Eq[Person] {
-    pub def eq(x: Person, y: Person): Bool = 
+    pub def eq(x: Person, y: Person): Bool =
         let Person(r1) = x;
         let Person(r2) = y;
-        r1.fstName == r2.fstName and r1.lstName == r2.lstName
+        r1#fstName == r2#fstName and r1#lstName == r2#lstName
 }
 ```
 

--- a/src/higher-kinded-types.md
+++ b/src/higher-kinded-types.md
@@ -2,7 +2,7 @@
 
 Flix supports [higher-kinded
 types](https://en.wikipedia.org/wiki/Kind_(type_theory)), hence traits can
-abstract over _type constructors_. 
+abstract over _type constructors_.
 
 For example, we can write a trait that capture iteration over any
 collection of the shape `t[a]` where `t` is a type constructor of kind
@@ -18,7 +18,7 @@ To use higher-kinded types Flix _requires_ us to provide kind annotations, i.e.
 we had to write `t: Type -> Type` to inform Flix that `ForEach` abstracts over
 type constructors.
 
-We can implement an instance of the `ForEach` trait for `Option[t]`: 
+We can implement an instance of the `ForEach` trait for `Option[t]`:
 
 ```flix
 instance ForEach[Option] {
@@ -38,7 +38,7 @@ instance ForEach[List] {
 ```
 
 > **Note**: Flix does not have a `ForEach` trait, but instead has the much
-> more powerful and versatile `Foldable` trait. 
+> more powerful and versatile `Foldable` trait.
 
 ### The Flix Kinds
 
@@ -46,7 +46,7 @@ Flix supports the following kinds:
 
 - `Type`: The kind of Flix types.
     - e.g. `Int32`, `String`, and `List[Int32]`.
-- `RecordRow`: The kind of rows used in records 
+- `RecordRow`: The kind of rows used in records
     - e.g. in `{x = Int32, y = Int32 | r}` the type variable `r` has kind `RecordRow`.
 - `SchemaRow`: The kind of rows used in first-class Datalog constraints
     - e.g. in `#{P(Int32, Int32) | r}` the type variable `r` has kind `SchemaRow`.
@@ -54,7 +54,7 @@ Flix supports the following kinds:
 Flix can usually infer kinds. For example, we can write:
 
 ```flix
-def sum(r: {x = t, y = t | r}): t with Add[t] = r.x + r.y
+def sum(r: {x = t, y = t | r}): t with Add[t] = r#x + r#y
 ```
 
 and have the kinds of `t: Type` and `r: RecordRow` automatically inferred.
@@ -62,7 +62,7 @@ and have the kinds of `t: Type` and `r: RecordRow` automatically inferred.
 We can also explicitly specify them as follows:
 
 ```flix
-def sum[t: Type, r: RecordRow](r: {x = t, y = t | r}): t with Add[t] = r.x + r.y
+def sum[t: Type, r: RecordRow](r: {x = t, y = t | r}): t with Add[t] = r#x + r#y
 ```
 
 but this style is not considered idiomatic.
@@ -75,17 +75,17 @@ Flix requires explicit kind annotations in four situations:
 - For type members of a non-Type kind in a trait.
 
 The most common scenario where you will need a kind annotation is when you want
-a type parameter or type member to range over an effect. 
+a type parameter or type member to range over an effect.
 
 ### Higher-Kinded Types vs. Associated Types
 
 In practice higher-kinded types and associated types can be used to define
-similar abstractions. 
+similar abstractions.
 
 For example, as we have seen, we can define the `ForEach` trait in two different
-ways: 
+ways:
 
-With a _higher-kinded type_: 
+With a _higher-kinded type_:
 
 ```flix
 trait ForEach[t: Type -> Type] {
@@ -105,7 +105,7 @@ trait ForEach[t] {
 In the case of `ForEach`, the definition with an associated type is more
 flexible, since we can implement an instance for `String` with associated
 element type `Char`. However, higher-kinded types are still useful. For example,
-the Flix Standard Library defines the `Functor` trait as: 
+the Flix Standard Library defines the `Functor` trait as:
 
 ```flix
 trait Functor[m : Type -> Type] {

--- a/src/introduction.md
+++ b/src/introduction.md
@@ -66,7 +66,7 @@ Here is an example that uses **polymorphic records**:
 /// Returns the area of the polymorphic record `r`.
 /// Note that the use of the type variable `a` permits the record `r`
 /// to have labels other than `x` and `y`.
-def polyArea[a : RecordRow](r: {x = Int32, y = Int32 | a}): Int32 = r.x * r.y
+def polyArea[a : RecordRow](r: {x = Int32, y = Int32 | a}): Int32 = r#x * r#y
 
 /// Computes the area of various rectangle records.
 /// Note that some records have additional labels.

--- a/src/records.md
+++ b/src/records.md
@@ -28,11 +28,11 @@ does not matter.
 
 ### Label Access
 
-We can access the label of a record using a dot:
+We can access the label of a record using a hash:
 
 ```flix
 let p = { x = 1, y = 2 };
-p.x + p.y
+p#x + p#y
 ```
 
 The type system ensures that we cannot access a label that does not exist.
@@ -48,7 +48,7 @@ record with an updated label value:
 ```flix
 let p1 = { x = 1, y = 2 };
 let p2 = { x = 3 | p1 };
-p1.x + p2.x
+p1#x + p2#x
 ```
 
 The expression `{ x = 3 | p1 }` updates the record `p1` with a new value of its
@@ -63,7 +63,7 @@ We can add a new label to an existing record as follows:
 ```flix
 let p1 = { x = 1, y = 2 };
 let p2 = { +z = 3 | p1 };
-p1.x + p1.y + p2.z
+p1#x + p1#y + p2#z
 ```
 
 Here the expression `{ +z = 3 | p1 }` extends the record `p1` with a new label
@@ -87,7 +87,7 @@ been removed.
 A function may specify that it requires a record with two labels:
 
 ```flix
-def f(r: {x = Int32, y = Int32}): Int32 = r.x + r.y
+def f(r: {x = Int32, y = Int32}): Int32 = r#x + r#y
 ```
 
 We can call this function with the records `{ x = 1, y = 2 }` and `{ y = 2, x =
@@ -98,7 +98,7 @@ say that the record `r` is *closed*.
 We can lift this restriction by using row polymorphism:
 
 ```flix
-def g(r: {x = Int32, y = Int32 | s}): Int32 = r.x + r.y
+def g(r: {x = Int32, y = Int32 | s}): Int32 = r#x + r#y
 ```
 
 We can call this function with *any* record as long as it has `x` and `y` labels

--- a/src/references.md
+++ b/src/references.md
@@ -10,8 +10,8 @@ change over time. The three key reference operations are:
 In Flix, the type of a reference is `Ref[t, r]` where `t` is the type of the
 element and `r` is its region. Like all mutable memory in Flix, every reference
 must belong to some region. Reading from and writing to a reference are
-_effectful_ operations. For example, reading the value of a reference `Ref[t,
-r]` has effect `r`.
+_effectful_ operations. For example, reading the value of a reference `Ref[t, r]`
+has effect `r`.
 
 The `Ref.fresh(rc, e)` operation allocates a reference cell in a region of the heap
 and returns its location, the `Ref.get` operation dereferences a location and
@@ -152,7 +152,7 @@ Similarly, here is a record that contains two mutable references:
 ```flix
 region rc {
     let r = { fstName = Ref.fresh(rc, "Lucky"), lstName = Ref.fresh(rc, "Luke") };
-    Ref.put("Unlucky", r.fstName)
+    Ref.put("Unlucky", r#fstName)
 };
 ```
 

--- a/src/type-level-programming.md
+++ b/src/type-level-programming.md
@@ -3,7 +3,7 @@
 > **Note:** This feature is experimental. Do not use in production.
 
 This section assumes prior familiarity with type-level programming and phantom
-types. 
+types.
 
 ### Type-Level Booleans
 
@@ -12,13 +12,13 @@ means `true` and `false` are types, but also that formulas such as `x and (not
 y)` are types. A type-level Boolean formulas has kind `Bool`. Two type-level
 Boolean formulas are equal if the formulas are equivalent (i.e. have the same
 truth tables). For example, the two types `true` and `x or not x` are _the same
-type_. 
+type_.
 
 While type-level Boolean formulas are not as expressive as general refinement
 types or dependent types they support complete type inference and parametric
-polymorphism. This means that they are very ergonomic to work with. 
+polymorphism. This means that they are very ergonomic to work with.
 
-We can use type-level Boolean formulas to statically enforce program invariants. 
+We can use type-level Boolean formulas to statically enforce program invariants.
 
 We illustrate with a few examples:
 
@@ -26,7 +26,7 @@ We illustrate with a few examples:
 
 ```flix
 ///
-/// We can use a phantom type-level Boolean to model whether a person is alive 
+/// We can use a phantom type-level Boolean to model whether a person is alive
 /// or is undead (i.e. a vampire).
 ///
 enum Person[_isAlive: Bool] {
@@ -34,7 +34,7 @@ enum Person[_isAlive: Bool] {
     case P({name = String, age = Int32})
 }
 
-/// 
+///
 /// We interpret the Boolean `true` is alive and the Boolean `false` as undead
 /// (i.e. a vampire).
 ///
@@ -42,7 +42,7 @@ type alias Alive  = true
 type alias Undead = false
 
 ///
-/// A person who is born is alive. 
+/// A person who is born is alive.
 ///
 def born(name: String): Person[Alive] =
     Person.P({name = name, age = 0})
@@ -50,8 +50,8 @@ def born(name: String): Person[Alive] =
 ///
 /// A person who is alive and is bitten becomes a vampire.
 ///
-/// Note that the type system enforces that an already undead (i.e. a vampire) 
-/// cannot be bitten again. 
+/// Note that the type system enforces that an already undead (i.e. a vampire)
+/// cannot be bitten again.
 ///
 def bite(p: Person[Alive]): Person[Undead] = match p {
     /// The implementation is not important; it simply restructs the person.
@@ -69,26 +69,26 @@ def marry(_p1: Person[isAlive], _p2: Person[isAlive]): Unit = ()
 
 ///
 /// We can implement a more sophisticated version of born.
-/// 
+///
 /// If two persons have a child then that child is a vampire if one of them is.
 ///
-/// Note that here we use the type-level computation `isAlive1 and isAlive2` 
+/// Note that here we use the type-level computation `isAlive1 and isAlive2`
 /// to compute whether the result is alive or undead.
 ///
-def offspring(p1: Person[isAlive1], p2: Person[isAlive2]): Person[isAlive1 and isAlive2] = 
+def offspring(p1: Person[isAlive1], p2: Person[isAlive2]): Person[isAlive1 and isAlive2] =
     match (p1, p2) {
-        case (Person.P(r1), Person.P(r2)) => 
-            Person.P({name = "Spawn of ${r1.name} and ${r2.name}", age = 0})
+        case (Person.P(r1), Person.P(r2)) =>
+            Person.P({name = "Spawn of ${r1#name} and ${r2#name}", age = 0})
 }
 
 ///
 /// A person can age-- no matter if they are alive or undead.
 ///
-/// Note that this function preserves the `isAlive` parameter. That is, if a 
+/// Note that this function preserves the `isAlive` parameter. That is, if a
 /// person is alive they stay alive.
 ///
 def birthday(p: Person[isAlive]): Person[isAlive] = match p {
-    case Person.P(r) => Person.P({name = r.name, age = r.age + 1})
+    case Person.P(r) => Person.P({name = r#name, age = r#age + 1})
 }
 ```
 
@@ -104,7 +104,7 @@ bite(p);
 If we compile this program then the Flix compiler emits a compiler error:
 
 ```
-❌ -- Type Error -------------------------------------------------- 
+❌ -- Type Error --------------------------------------------------
 
 >> Expected argument of type 'Person[true]', but got 'Person[false]'.
 


### PR DESCRIPTION
Searched through the repo with regex `([a-z]+)\w*\.[a-z]`

Related to https://github.com/flix/flix/issues/7897