### PR TITLE
chore: update `next-steps.md`

### DIFF
--- a/src/next-steps.md
+++ b/src/next-steps.md
@@ -56,7 +56,7 @@ version is:
 def main(): Unit \ IO = 
     let args = Environment.getArgs();
     let result = 
-        for (
+        forM (
             file  <- List.head(args) |> 
                      Option.toOk("Missing argument: filename");
             lines <- Files.readLines(file) |>


### PR DESCRIPTION
Changed "for" to "forM" to match newest valid flix syntax for monadic for-yield.