### PR TITLE
chore: reflect renaming of `debug` to `dbg`

### DIFF
--- a/src/debugging.md
+++ b/src/debugging.md
@@ -29,35 +29,35 @@ cannot use it to debug our pure functions! We could make our `sum` function have
 the `IO` effect, but that is rarely what we want. Fortunately, Flix has a
 built-in debugging facility that allows us to do print-line debugging.
 
-### The debug Function
+### The dbg Function
 
-Flix has a `debug` function with the same signature as the `identity` function:
+Flix has a `dbg` (short for "debug") function, with the same signature as the `identity` function:
 
 ```flix
-def debug(x: a): a
+def dbg(x: a): a
 ```
 
-The `debug` "function" isn't really a function; rather its internal compiler
+The `dbg` "function" isn't really a function; rather its internal compiler
 magic that allows you to print _any value_ while fooling the type and effect
-system into believing that it is still pure. Using the `debug` function this
+system into believing that it is still pure. Using the `dbg` function this
 program:
 
 ```flix
 def sum(x: Int32, y: Int32): Int32 =
-    debug(x);
-    debug(y);
+    dbg(x);
+    dbg(y);
     x + y
 ```
 
 Now compiles and runs.
 
-The `debug` function returns its argument. Hence its convenient to use in many
+The `dbg` function returns its argument. Hence its convenient to use in many
 situations.
 
 For example, we can write:
 
 ```flix
-def sum(x: Int32, y: Int32): Int32 = debug(x + y)
+def sum(x: Int32, y: Int32): Int32 = dbg(x + y)
 ```
 
 to print the value of `x + y` _and_ return it.
@@ -66,7 +66,7 @@ We can also use it inside e.g. a `for-yield` expression:
 
 ```flix
 for(i <- List.range(0, 10);
-    j <- debug(List.range(i, 10)))
+    j <- dbg(List.range(i, 10)))
     yield (i, j)
 ```
 
@@ -74,19 +74,19 @@ Or in a pipeline:
 
 ```flix
 List.range(1, 100) |>
-List.map(x -> debug(x + 1)) |>
-List.filter(x -> debug(x > 5))
+List.map(x -> dbg(x + 1)) |>
+List.filter(x -> dbg(x > 5))
 ```
 
 ### Debug Format
 
-The `debug` expression (and its variants) do _not_ use the `ToString` trait.
+The `dbg` expression (and its variants) do _not_ use the `ToString` trait.
 Instead they print the internal Flix representation of the given value.
 
 For example, the expression:
 
 ```flix
-debug(1 :: 2 :: Nil)
+dbg(1 :: 2 :: Nil)
 ```
 
 prints:
@@ -98,7 +98,7 @@ Cons(1, Cons(2, Nil))
 We can also print values that do not have a `ToString` instance:
 
 ```flix
-debug(x -> x + 123)
+dbg(x -> x + 123)
 ```
 
 prints:
@@ -111,24 +111,24 @@ We can always obtain the `ToString` representation by using an interpolated
 string. For example:
 
 ```flix
-debug("${x}")
+dbg("${x}")
 ```
 
 ### Debug Variants
 
-The `debug` function comes in three variants:
+The `dbg` function comes in three variants:
 
-- `debug`: Prints its argument.
-- `debug!`: Prints its argument and source location.
-- `debug!!`: Prints its argument, source location, and source code.
+- `dbg`: Prints its argument.
+- `dbg!`: Prints its argument and source location.
+- `dbg!!`: Prints its argument, source location, and source code.
 
 The following program:
 
 ```flix
 def main(): Unit =
-    debug("A message");
-    debug!("Another message");
-    debug!!("A third message");
+    dbg("A message");
+    dbg!("Another message");
+    dbg!!("A third message");
     ()
 ```
 
@@ -140,12 +140,12 @@ prints:
 [C:\tmp\flix\Main.flix:4] A third message = "A third message"
 ```
 
-The third `debug!!` variant is intended to be used in situations like:
+The third `dbg!!` variant is intended to be used in situations like:
 
 ```flix
 let x = 123;
 let y = 456;
-debug!!(x + y)
+dbg!!(x + y)
 ```
 
 where it prints:
@@ -154,9 +154,9 @@ where it prints:
 [C:\tmp\flix\Main.flix:3] x + y = 579
 ```
 
-> **Note:** The `debug` expression should not be used in production code.
+> **Note:** The `dbg` expression should not be used in production code.
 
-> **Warning:** The Flix compiler treats the `debug` expression as pure, hence
+> **Warning:** The Flix compiler treats the `dbg` expression as pure, hence
 > under certain circumstances the compiler may reorder or entirely remove a use
-> of `debug`.
+> of `dbg`.
 


### PR DESCRIPTION
Related to flix/flix#8888