### PR TITLE
fix: correct concurrency example

### DIFF
--- a/src/concurrency.md
+++ b/src/concurrency.md
@@ -157,7 +157,7 @@ def slow(tx: Sender[String]): Unit \ {Chan, IO} =
 def main(): Unit \ {Chan, NonDet, IO} = region rc {
     let (tx, rx) = Channel.buffered(1);
     spawn slow(tx) @ rc;
-    let timeout = Channel.timeout(rc, Time.Duration.fromSeconds(5));
+    let timeout = Channel.timeout(Time.Duration.fromSeconds(5));
     select {
         case m <- recv(rx)       => m
         case _ <- recv(timeout)  => "timeout"


### PR DESCRIPTION
Removing the invalid Region parameter that is being passed to `Channel.timeout` in the concurrency example.

Reference: https://api.flix.dev/Channel.html