### PR TITLE
doc: add Emacs section to getting started guide

### DIFF
--- a/src/getting-started.md
+++ b/src/getting-started.md
@@ -215,6 +215,10 @@ There are many other neovim plugins that can enhance your Flix programming exper
 
 ![Visual Studio Code1](images/neovim.png)
 
+### Using Flix from Emacs
+
+Flix can be used from [Emacs](https://www.gnu.org/software/emacs/) as well by installing the [flix-mode](https://codeberg.org/mdiin/flix-mode) package. Follow the instructions there to get started writing Flix code in Emacs. 
+
 ### Using Flix from the Command Line
 
 Flix can also be used from the command line. Follow these steps:


### PR DESCRIPTION
# News

- Add a small section to the "Getting Started" guide on using Emacs

# Notes

I have intentionally left out the details, instead pointing to the `flix-mode` package documentation. That way the getting started guide does not need to be updated if/when the setup of `flix-mode` for Emacs changes.