### PR TITLE
fix: corrected penguin classification (typo)

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -9,3 +9,4 @@ By adding your name to this document, you agree to release all your contribution
 - [Rutvik Patel](https://github.com/heyrutvik)
 - [Stephen Bastians](https://github.com/stetimi)
 - [Jonathan Lindegaard Starup](https://github.com/JonathanStarup)
+- [Michał Kukieła](https://github.com/kukimik)

--- a/src/traits.md
+++ b/src/traits.md
@@ -115,7 +115,7 @@ mod Zoo {
     }
 
     instance Animal[Penguin] {
-        pub def isMammal(_: Penguin): Bool = true
+        pub def isMammal(_: Penguin): Bool = false
     }
 
     pub enum Giraffe


### PR DESCRIPTION
Technically it's not a bug, but it may be confusing to some readers.