### PR TITLE
docs: show that exception stops execution in the divByZero example

### DIFF
--- a/src/effects-and-handlers.md
+++ b/src/effects-and-handlers.md
@@ -61,7 +61,7 @@ the following works without issue:
 
 ```flix
 def main(): Unit \ IO = 
-    let l = List#{1, 2, 0};
+    let l = List#{1, 2, 0, 3};
     run {
         List.map(x -> println(divide(42, x)), l);
         ()


### PR DESCRIPTION
While reading this example (and the preceding example without lists) at first I wasn't sure what will happen when there is another element in the list. As one may expect, the execution halts after `0` is processed (so no result for division by 3 is printed out), but I think it may be beneficial to state this explicitly.