### PR TITLE
Typos, minor fixes

### DIFF
--- a/src/build-and-packages.md
+++ b/src/build-and-packages.md
@@ -27,8 +27,8 @@ already present.
 
 ## Project Structure
 
-Flix scans for source files in the paths `*.flix`, `src/**.flix,`, and
-`test/**.flix`.
+Flix scans for source files in the paths `*.flix`, `src/**/*.flix,`, and
+`test/**/*.flix`.
 
-Flix scans for Flix packages and JARs in the paths `lib/**.fpkg` and
-`lib/**.jhar`.
+Flix scans for Flix packages and JARs in the paths `lib/**/*.fpkg` and
+`lib/**/*.jar`.

--- a/src/calling-methods.md
+++ b/src/calling-methods.md
@@ -97,7 +97,7 @@ def main(): Unit \ IO =
 ## Calling Constructors or Methods with VarArgs
 
 We can call a constructor or method that takes variable arguments using the
-the special syntax `...{ value1, value2, ...}`. For example:
+special syntax `...{ value1, value2, ...}`. For example:
 
 ```flix
 import java.nio.file.Path

--- a/src/checked-casts.md
+++ b/src/checked-casts.md
@@ -88,7 +88,7 @@ because in Flix a _pure_ function is _not_ a subtype of an impure function.
 Specifically, the `hof` requires a function with the `IO` effect, but we are
 passing in a pure function. 
 
-We can use a checked effect cast to safely upcast upcast a pure expression to an
+We can use a checked effect cast to safely upcast a pure expression to an
 impure expression: 
 
 ```flix
@@ -112,7 +112,7 @@ For example, the following does not work:
 let f: Unit -> ##java.lang.Object = checked_cast(() -> "Hello World")
 ```
 
-because it tries to cast the function type `Unit -> String` to `String ->
+because it tries to cast the function type `Unit -> String` to `Unit ->
 Object`.
 
 Instead, we should write:

--- a/src/debugging.md
+++ b/src/debugging.md
@@ -37,7 +37,7 @@ Flix has a `dbg` (short for "debug") function, with the same signature as the `i
 def dbg(x: a): a
 ```
 
-The `dbg` "function" isn't really a function; rather its internal compiler
+The `dbg` "function" isn't really a function; rather it's internal compiler
 magic that allows you to print _any value_ while fooling the type and effect
 system into believing that it is still pure. Using the `dbg` function this
 program:
@@ -51,7 +51,7 @@ def sum(x: Int32, y: Int32): Int32 =
 
 Now compiles and runs.
 
-The `dbg` function returns its argument. Hence its convenient to use in many
+The `dbg` function returns its argument. Hence it's convenient to use in many
 situations.
 
 For example, we can write:

--- a/src/effect-polymorphism.md
+++ b/src/effect-polymorphism.md
@@ -121,7 +121,7 @@ In Flix, the language of effects is based on set formulas:
 
 By far the most common operation is to compute the union of effects.
 
-Its important to understand that there can be several ways to write the same
+It's important to understand that there can be several ways to write the same
 effect set. For example, `ef1 + ef2` is equivalent to `ef2 + ef1`, as one would
 expect. 
 

--- a/src/holes.md
+++ b/src/holes.md
@@ -59,7 +59,7 @@ As another example, in the program:
 def main(): Unit \ IO = 
     let l: List[Int32] = List.range(1, 10);
     let n: Int32 = l?;
-    println("The value of `n` is ${n + 0}.")
+    println("The value of `n` is ${n}.")
 ```
 
 If we place the cursor on `l?`, Flix will suggest:

--- a/src/java-collections.md
+++ b/src/java-collections.md
@@ -6,8 +6,12 @@ In the following, we use the following import aliases:
 
 ```flix
 import java.util.{List => JList}
+import java.util.{LinkedList => JLinkedList}
+import java.util.{ArrayList => JArrayList}
 import java.util.{Set => JSet}
+import java.util.{TreeSet => JTreeSet}
 import java.util.{Map => JMap}
+import java.util.{TreeMap => JTreeMap}
 ```
 
 The following functions are available in the
@@ -21,21 +25,21 @@ The following functions _convert_ Flix collections to Java collections:
 ///
 /// Lists
 ///
-def toList(ma: m[a]): JList \ IO with Foldable[m]
-def toArrayList(ma: m[a]): ArrayList \ IO with Foldable[m]
-def toLinkedList(ma: m[a]): LinkedList \ IO with Foldable[m]
+def toList(ma: m[a]): JList \ IO + Aef[m] with Foldable[m]
+def toArrayList(ma: m[a]): JArrayList \ IO + Aef[m] with Foldable[m]
+def toLinkedList(ma: m[a]): JLinkedList \ IO + Aef[m] with Foldable[m]
 
 ///
 /// Sets
 ///
-def toSet(ma: m[a]): Set \ IO with Order[a], Foldable[m]
-def toTreeSet(ma: m[a]): TreeSet \ IO with Order[a], Foldable[m]
+def toSet(ma: m[a]): JSet \ IO + Aef[m] with Order[a], Foldable[m]
+def toTreeSet(ma: m[a]): JTreeSet \ IO + Aef[m] with Order[a], Foldable[m]
 
 ///
 /// Maps
 ///
 def toMap(m: Map[k, v]): JMap \ IO with Order[k]
-def toTreeMap(m: Map[k, v]): TreeMap \ IO with Order[k] 
+def toTreeMap(m: Map[k, v]): JTreeMap \ IO with Order[k]
 ```
 
 Each function constructs a new collection and copies all its elements into it.

--- a/src/redundancy.md
+++ b/src/redundancy.md
@@ -137,7 +137,7 @@ with the message:
 The expression has type 'Result[String, Int64]'
 ```
 
-Even though `File.creationTime` has a side-effects, we should probably be using the result `Result[String, Int64]`.
+Even though `File.creationTime` has a side-effect, we should probably be using the result `Result[String, Int64]`.
 At least to ensure that the operation was successful.
 
 If the result of an impure expression is truly not needed, then the `discard` expression can be used:

--- a/src/tools.md
+++ b/src/tools.md
@@ -3,5 +3,4 @@
 This chapter covers the tooling which Flix ships with, including:
 
 - A fully-featured [Visual Studio Code extension](./vscode.md).
-- A [package manager](./build-and-packages.md).
 - A built-in [test framework](./test-framework.md).

--- a/src/type-ascriptions.md
+++ b/src/type-ascriptions.md
@@ -13,7 +13,7 @@ A type ascription can be placed after an expression:
 
 but it must be wrapped in parentheses to disambiguate it from other expressions.
 
-It can also be placed on a let-binding parentheses:
+It can also be placed on a let-binding without parentheses:
 
 ```flix
 let l: List[String] = "Hello" :: "World" :: Nil
@@ -31,7 +31,7 @@ def fst1[a: Type, b: Type](p: (a, b)): a = let (x, _) = p; x
 
 Here we have specified that the _kind_ of the two type parameters `a` and `b` is
 `Type`. We will typically never have to specify such kinds since they can
-inferred.
+be inferred.
 
 We can also provide kind ascriptions on algebraic data types:
 

--- a/src/type-match.md
+++ b/src/type-match.md
@@ -64,7 +64,7 @@ def main(): Unit \ IO =
 > should be used sparingly and with great care.
 
 A typical legitimate use case for type match is when we want to work around
-limitations imposed by the JVM. For example, the Flix Standard Library use type
+limitations imposed by the JVM. For example, the Flix Standard Library uses type
 match to implement the `Array.copyOfRange` function as shown below:
 
 ```flix


### PR DESCRIPTION
Mostly typos.

* `src/tools.md`: the build tools and package manager are now discussed in a separate chapter;
* `src/holes.md`: the `n+0` isn't technically wrong, but it's unnecessary and confusing
