### PR TITLE
feat: add footnote explaining the char type

### DIFF
--- a/src/primitive-types.md
+++ b/src/primitive-types.md
@@ -6,7 +6,7 @@ Flix supports the primitive types:
 |--------------|------------------------------------------|-----------------------------------|
 | Unit         | `()`                                     | The unit value.                   |
 | Bool         | `true`, `false`                          | A boolean value.                  |
-| Char         | `'a'`, `'b'`, `'c'`                      | A character value.                |
+| Char         | `'a'`, `'b'`, `'c'`                      | A character[^1] value.            |
 | Float32      | `0.0f32`, `21.42f32`, `-21.42f32`        | A 32-bit floating point integer.  |
 | Float64      | `0.0f64`, `21.42f64`, `-21.42f64`        | A 64-bit floating point integer.  |
 | Int8         | `0i8`, `1i8`, `-1i8`, `127i8`, `-128i8`  | A signed 8-bit integer.           |
@@ -93,3 +93,7 @@ Additionally, regex literals support regex escape sequences with the following n
 Regex.isMatch(regex"\\w", "W")
 ```
 
+[^1]: More precisely, a `Char` value corresponds to a single UTF-16 code unit. UTF-16 is a variable length encoding:
+    some of the Unicode code points are represented by a single UTF-16 code unit, but others need two code units.
+    (Also note that a combination of several Unicode code points may be needed to represent what is usually perceived as
+    a single character.)


### PR DESCRIPTION
Discussed on gitter:

> Hi! Did I get it right that a Char value corresponds to a single UTF-16 code unit (two bytes)? Which means that [since Unicode 2.0](https://en.wikibooks.org/wiki/Unicode/Versions#Unicode_2.0) two Chars may be needed to represent some of the Unicode code points - UTF-16 is a variable length encoding. The docs (both the book and the standard library documentation, e.g. https://api.flix.dev/String.html#def-toList) say that Char is a character value, but in the world of Unicode the meaning of "character" is ambiguous. I ended up searching what Java's char is (I have little experience with the Java ecosystem), which needed some time. I think it may be helpful to say this explicitly in the docs. I can create a PR adding a footnote to https://doc.flix.dev/primitive-types.html, but I'd like to know your opinion first (and make sure I understand this correctly).
>
> **Matt Lutze**
> Yes, you got it right. Flix uses Java's meaning of character, which is UTF-16