### PR TITLE
fix: replace removed Thread.sleep in concurrency.md (#314)

### DIFF
--- a/src/concurrency.md
+++ b/src/concurrency.md
@@ -18,15 +18,11 @@ Spawned processes are always associated with a region; the region
 will not exit until all the processes associated with it have completed:
 
 ```flix
-def slowPrint(delay: Int32, message: String): Unit \ IO =
-    Thread.sleep(Time.Duration.fromSeconds(delay));
-    println(message)
-
 def main(): Unit \ IO =
     region r1 {
         region r2 {
-            spawn slowPrint(2, "Hello from r1") @ r1;
-            spawn slowPrint(1, "Hello from r2") @ r2
+            spawn println("Hello from r1") @ r1;
+            spawn println("Hello from r2") @ r2
         };
         println("r2 is now complete")
     };
@@ -150,14 +146,15 @@ a channel, but the `select` expression relies on
 giving up:
 
 ```flix
-def slow(tx: Sender[String]): Unit \ {Chan, IO} =
-    Thread.sleep(Time.Duration.fromSeconds(60));
+def slow(tx: Sender[String]): Unit \ {Chan, NonDet, IO} =
+    let delay = Channel.timeout(60, Time.TimeUnit.Seconds);
+    Channel.recv(delay);
     Channel.send("I am very slow", tx)
 
 def main(): Unit \ {Chan, NonDet, IO} = region rc {
     let (tx, rx) = Channel.buffered(1);
     spawn slow(tx) @ rc;
-    let timeout = Channel.timeout(Time.Duration.fromSeconds(5));
+    let timeout = Channel.timeout(5, Time.TimeUnit.Seconds);
     select {
         case m <- recv(rx)       => m
         case _ <- recv(timeout)  => "timeout"


### PR DESCRIPTION
## Summary

`Thread.sleep` has been removed from Flix (#314). The only references were in `src/concurrency.md`. Two related APIs are also gone in the current version: `Time.Duration.fromSeconds(...)` and the single-argument `Channel.timeout(...)`.

## Changes

- **Structured-concurrency example** — removed the `slowPrint` helper, which only existed to inject a `Thread.sleep` delay; now spawns `println` directly. The region-lifetime point it illustrates is unchanged.
- **Timeout example** — the `slow` sender genuinely needs to be slow or the `select` timeout never fires. The new `Sleep` effect is not allowed inside `spawn`, so the delay is reproduced with a `Channel.timeout` receiver (`Chan + IO`, both legal in `spawn`). Updated both `Channel.timeout` calls to the two-argument `(Int32, Time.TimeUnit)` form.

No prose changes were needed — surrounding text remains accurate (the slow function still takes a minute; the program still prints `"timeout"` after five seconds).

## Verification

Both examples checked against the current API (api.flix.dev) and compiled cleanly with `flix check` (Flix 0.72.0).

Closes #314

🤖 Generated with [Claude Code](https://claude.com/claude-code)