### PR TITLE
docs: add Rock the JVM interview to videos.md

### DIFF
--- a/src/videos.md
+++ b/src/videos.md
@@ -4,6 +4,8 @@ A collection of videos about Flix.
 
 ## Industry Talks
 
+- **[Everything About the Flix Language](https://www.youtube.com/watch?v=qMyl2kyDI0I)**\
+  *Magnus Madsen @ Rock the JVM 2026*
 - **[Four Fascinating Programming Languages You've Probably Never Heard Of](https://www.youtube.com/watch?v=_rHoHLanuQg)**\
   *Lutz Hühnken @ BOB 2026*
 - **[An Introduction to Effectful Programming in Flix](https://www.youtube.com/watch?v=DHB4SvB7g84)**\


### PR DESCRIPTION
Adds the Rock the JVM podcast interview with Magnus Madsen to the Industry Talks section of `videos.md`.

- **Video:** [Everything About the Flix Language](https://www.youtube.com/watch?v=qMyl2kyDI0I)
- **Speaker/venue:** Magnus Madsen @ Rock the JVM 2026 (published Jun 24, 2026)
- Placed at the top of Industry Talks to keep the section newest-first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)