### PR TITLE
docs: restructure and update research literature page

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -108,7 +108,7 @@
 ---
 
 - [Additional Information](./additional-information.md)
-  - [Research Literature](./research-literature.md)
   - [Blog Posts](./blog-posts.md)
   - [Videos](./videos.md)
   - [For LLMs](./for-llms.md)
+  - [Research Literature](./research-literature.md)

--- a/src/additional-information.md
+++ b/src/additional-information.md
@@ -2,11 +2,12 @@
 
 More information about the Flix programming language can be found in:
 
-- The [research literature](./research-literature.md) written by programming
-  language researchers.
 - A series of [blog posts](./blog-posts.md) written by the community.
+- A collection of [videos](./videos.md) of industry and research talks.
 - A page [for LLMs](./for-llms.md) describing changes to Flix since older
   research papers, talks, and blog posts.
+- The [research literature](./research-literature.md) written by programming
+  language researchers.
 
 ## Getting Help
 

--- a/src/research-literature.md
+++ b/src/research-literature.md
@@ -1,14 +1,56 @@
 # Research Literature
 
-The following research papers cover specific aspects of Flix:
+The following research papers cover specific aspects of Flix.
 
-- [The Principles of the Flix Programming Language](https://dl.acm.org/doi/10.1145/3563835.3567661)
-- [Flix: A Meta Programming Language for Datalog](https://ceur-ws.org/Vol-3203/short8.pdf)
-- [Relational Nullable Types with Boolean Unification](https://dl.acm.org/doi/abs/10.1145/3485487)
-- [Fixpoints for the Masses: Programming with First-Class Datalog Constraints](https://dl.acm.org/doi/10.1145/3428193)
-- [Polymorphic Types and Effects with Boolean Unification](https://dl.acm.org/doi/10.1145/3428222)
-- [Implicit Parameters for Logic Programming](https://dl.acm.org/doi/abs/10.1145/3236950.3236953)
-- [Safe and Sound Program Analysis with Flix](https://dl.acm.org/doi/10.1145/3213846.3213847)
-- [Tail Call Elimination and Data Representation for Functional Languages on the Java Virtual Machine](https://dl.acm.org/doi/abs/10.1145/3178372.3179499)
-- [From Datalog to Flix: A Declarative Language for Fixed Points on Lattices](https://dl.acm.org/doi/10.1145/2980983.2908096)
-- [Programming a Dataflow Analysis in Flix](https://staticanalysis.org/tapas2016/abstracts/TAPAS_2016_MadsenEtAl.pdf)
+Flix has evolved significantly since many of these papers were published. The
+book is the authoritative reference for the current language.
+
+## Language Design
+
+- **[The Principles of the Flix Programming Language](https://dl.acm.org/doi/10.1145/3563835.3567661)**\
+  *Magnus Madsen @ Onward! 2022*
+
+## Types and Effects
+
+- **[Qualified Types with Boolean Algebras](https://dl.acm.org/doi/10.1145/3763096)**\
+  *Edward Lee, Jonathan Lindegaard Starup, Ondřej Lhoták, Magnus Madsen @ OOPSLA 2025*
+- **[Associated Effects: Flexible Abstractions for Effectful Programming](https://dl.acm.org/doi/10.1145/3656393)**\
+  *Matthew Lutze, Magnus Madsen @ PLDI 2024* (see [Associated Effects](./associated-effects.md))
+- **[Fast and Efficient Boolean Unification for Hindley-Milner-Style Type and Effect Systems](https://dl.acm.org/doi/10.1145/3622816)**\
+  *Magnus Madsen, Jaco van de Pol, Troels Henriksen @ OOPSLA 2023*
+- **[With or Without You: Programming with Effect Exclusion](https://dl.acm.org/doi/10.1145/3607846)**\
+  *Matthew Lutze, Magnus Madsen, Philipp Schuster, Jonathan Immanuel Brachthäuser @ ICFP 2023*
+- **[Programming with Purity Reflection: Peaceful Coexistence of Effects, Laziness, and Parallelism](https://doi.org/10.4230/LIPIcs.ECOOP.2023.18)**\
+  *Magnus Madsen, Jaco van de Pol @ ECOOP 2023* — Distinguished Paper Award (see [Purity Reflection](./purity-reflection.md))
+- **[Restrictable Variants: A Simple and Practical Alternative to Extensible Variants](https://doi.org/10.4230/LIPIcs.ECOOP.2023.17)**\
+  *Magnus Madsen, Jonathan Lindegaard Starup, Matthew Lutze @ ECOOP 2023*
+- **[Relational Nullable Types with Boolean Unification](https://dl.acm.org/doi/10.1145/3485487)**\
+  *Magnus Madsen, Jaco van de Pol @ OOPSLA 2021*
+- **[Polymorphic Types and Effects with Boolean Unification](https://dl.acm.org/doi/10.1145/3428222)**\
+  *Magnus Madsen, Jaco van de Pol @ OOPSLA 2020*
+
+## Datalog and Fixpoints
+
+- **[Flix: A Design for Language-Integrated Datalog](https://dl.acm.org/doi/10.1145/3763126)**\
+  *Magnus Madsen, Ondřej Lhoták @ OOPSLA 2025* — Distinguished Artifact (see [Fixpoints](./fixpoints.md))
+- **[Breaking the Negative Cycle: Exploring the Design Space of Stratification for First-Class Datalog Constraints](https://doi.org/10.4230/LIPIcs.ECOOP.2023.31)**\
+  *Jonathan Lindegaard Starup, Magnus Madsen, Ondřej Lhoták @ ECOOP 2023* (see [Stratified Negation](./stratified-negation.md))
+- **[Flix: A Meta Programming Language for Datalog](https://ceur-ws.org/Vol-3203/short8.pdf)**\
+  *Magnus Madsen, Jonathan Lindegaard Starup, Ondřej Lhoták @ Datalog 2.0 2022*
+- **[Fixpoints for the Masses: Programming with First-Class Datalog Constraints](https://dl.acm.org/doi/10.1145/3428193)**\
+  *Magnus Madsen, Ondřej Lhoták @ OOPSLA 2020*
+- **[Implicit Parameters for Logic Programming](https://dl.acm.org/doi/10.1145/3236950.3236953)**\
+  *Magnus Madsen, Ondřej Lhoták @ PPDP 2018*
+- **[Safe and Sound Program Analysis with Flix](https://dl.acm.org/doi/10.1145/3213846.3213847)**\
+  *Magnus Madsen, Ondřej Lhoták @ ISSTA 2018*
+- **[From Datalog to Flix: A Declarative Language for Fixed Points on Lattices](https://dl.acm.org/doi/10.1145/2908080.2908096)**\
+  *Magnus Madsen, Ming-Ho Yee, Ondřej Lhoták @ PLDI 2016* (see [Lattice Semantics](./lattice-semantics.md))
+- **[Programming a Dataflow Analysis in Flix](https://staticanalysis.org/tapas2016/abstracts/TAPAS_2016_MadsenEtAl.pdf)**\
+  *Magnus Madsen, Ming-Ho Yee, Ondřej Lhoták @ TAPAS 2016*
+
+## Compilation
+
+- **[Overloading the Dot](https://dl.acm.org/doi/10.1145/3708493.3712684)**\
+  *Joseph Tan, Magnus Madsen @ CC 2025*
+- **[Tail Call Elimination and Data Representation for Functional Languages on the Java Virtual Machine](https://dl.acm.org/doi/10.1145/3178372.3179499)**\
+  *Magnus Madsen, Ramin Zarifi, Ondřej Lhoták @ CC 2018*

--- a/src/research-literature.md
+++ b/src/research-literature.md
@@ -1,9 +1,9 @@
 # Research Literature
 
-The following research papers cover specific aspects of Flix.
-
-Flix has evolved significantly since many of these papers were published. The
-book is the authoritative reference for the current language.
+The following research papers cover specific aspects of Flix. They are written
+for a research audience and are not necessarily accessible to the general
+reader. Flix has also evolved significantly since many of these papers were
+published; the book is the authoritative reference for the current language.
 
 ## Language Design
 

--- a/src/research-literature.md
+++ b/src/research-literature.md
@@ -1,9 +1,9 @@
 # Research Literature
 
 The following research papers cover specific aspects of Flix. They are written
-for a research audience and are not necessarily accessible to the general
-reader. Flix has also evolved significantly since many of these papers were
-published; the book is the authoritative reference for the current language.
+for a research audience and not necessarily accessible to the general reader.
+Flix has evolved significantly since many of these papers were published; the
+book is the authoritative reference for the current language.
 
 ## Language Design
 


### PR DESCRIPTION
Reworks `research-literature.md`, which was a flat list of ten bare titles with no authors, venue, or year, and had not been updated since 2022.

## Presentation

Adopts the same entry format as `videos.md` — bold linked title, then authors, venue, and year in italics:

```markdown
- **[The Principles of the Flix Programming Language](https://dl.acm.org/doi/10.1145/3563835.3567661)**\
  *Magnus Madsen @ Onward! 2022*
```

Papers are grouped into **Language Design**, **Types and Effects**, **Datalog and Fixpoints**, and **Compilation**, reverse-chronological within each section.

## Content

- Adds the nine papers published since 2022: Language-Integrated Datalog, Qualified Types with Boolean Algebras, Overloading the Dot, Associated Effects, With or Without You, Fast and Efficient Boolean Unification, Restrictable Variants, Purity Reflection, and Breaking the Negative Cycle. The book already linked talks for two of these in `videos.md` but not the papers themselves.
- Notes the Distinguished Paper Award (Purity Reflection) and Distinguished Artifact (Language-Integrated Datalog).
- Cross-links the five papers that have a corresponding chapter.
- Adds a note that Flix has evolved since many of these papers were published.
- Moves the page last under Additional Information in `SUMMARY.md`, and reorders `additional-information.md` to match. That prose list was also missing Videos, so it is now added.

## Verification

- All 18 DOIs resolve through `doi.org`; both direct PDF links return 200.
- Every title, author list, author order, venue, and year was checked against https://cs.au.dk/~magnusm/. The three ECOOP LIPIcs numbers were each confirmed against Dagstuhl to match the right paper.
- The TAPAS 2016 entry is not on the homepage; its authors were confirmed from the abstract PDF.
- `mdbook build` succeeds and all internal links resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)