### PR TITLE
feat: Expand the Emacs section

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -10,3 +10,4 @@ By adding your name to this document, you agree to release all your contribution
 - [Stephen Bastians](https://github.com/stetimi)
 - [Jonathan Lindegaard Starup](https://github.com/JonathanStarup)
 - [Michał Kukieła](https://github.com/kukimik)
+- [Kent OHASHI](https://github.com/lagenorhynque)

--- a/src/getting-started.md
+++ b/src/getting-started.md
@@ -177,7 +177,21 @@ LSP is not attached, and reports an error if no `flix.toml` is found.
 
 ## Using Flix from Emacs
 
-Flix can be used from [Emacs](https://www.gnu.org/software/emacs/) as well by installing the [flix-mode](https://codeberg.org/mdiin/flix-mode) package. Follow the instructions there to get started writing Flix code in Emacs.
+Flix can be used from [Emacs](https://www.gnu.org/software/emacs/), either in
+plain Emacs or in [Spacemacs](https://www.spacemacs.org/). Both drive the Flix
+compiler's LSP server for full language support.
+
+### Plain Emacs
+
+Install the [flix-mode](https://github.com/flix/emacs) package (the major
+mode) and configure it with an LSP client (`eglot` or `lsp-mode`). Its README
+has minimal, ready-to-use configurations for both.
+
+### Spacemacs
+
+Add the [flix layer](https://github.com/flix/spacemacs), which wires up
+flix-mode with `lsp-mode` and the Spacemacs key-binding system. Its README has
+installation and configuration instructions.
 
 ## Using Flix from the CLI
 


### PR DESCRIPTION
[The Getting Started page](https://doc.flix.dev/getting-started.html#using-flix-from-emacs) mentioned only flix-mode in a single line. This expands the Emacs section to cover both ways of using Flix from Emacs:

- **Plain Emacs** — [flix-mode](https://github.com/flix/emacs) with `eglot` or `lsp-mode`
- **Spacemacs** — [the flix layer](https://github.com/flix/spacemacs)

Both are now hosted in the Flix org (discussed on Zulip with @magnus-madsen and @mdiin). The flix-mode link is updated from its old Codeberg location to `flix/emacs` accordingly.

Following the style of the other editor sections, setup details (configuration snippets, key bindings) are left to each project's README, so this page stays easy to maintain.